### PR TITLE
Add version change comments on PRs with `whippet.lock` changes

### DIFF
--- a/.github/workflows/whippet-dependencies-validate.yml
+++ b/.github/workflows/whippet-dependencies-validate.yml
@@ -2,12 +2,19 @@ name: Validate Whippet files
 
 on: 
   workflow_call:
+    secrets:
+      GH_ACCOUNT_TOKEN:
+        required: true
 
 jobs:
   whippet-deps:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_ACCOUNT_TOKEN }}
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -26,3 +33,71 @@ jobs:
         run: composer install --no-interaction
       - name: Run Whippet deps validate
         run: vendor/bin/whippet deps validate
+      - name: Check for changes to whippet.lock
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v2
+        id: whippet_lock_change
+        with:
+          filters: |
+            src:
+              - 'whippet.lock'
+      - name: authenticate with GitHub CLI and setup git
+        if: steps.whippet_lock_change.outputs.src == 'true' && github.event_name == 'pull_request'
+        run: |
+          echo "${{ secrets.GH_ACCOUNT_TOKEN }}" | gh auth login --with-token -p https
+          gh auth setup-git
+          git config --global url."https://github.com/".insteadOf 'git@github.com:'
+      - name: Whippet describe current branch
+        if: steps.whippet_lock_change.outputs.src == 'true' && github.event_name == 'pull_request'
+        run: |
+          if test -f "whippet.lock"; then
+            EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+            echo "DESCRIBE_PR_BRANCH<<$EOF" >> "$GITHUB_ENV"
+            vendor/bin/whippet deps describe >> "$GITHUB_ENV"
+            echo -e "\n" >> "$GITHUB_ENV"
+            echo "$EOF" >> "$GITHUB_ENV"
+          else
+            echo "DESCRIBE_PR_BRANCH=''" >> "$GITHUB_ENV"
+          fi
+      - name: Checkout target branch
+        if: steps.whippet_lock_change.outputs.src == 'true' && github.event_name == 'pull_request'
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          token: ${{ secrets.GH_ACCOUNT_TOKEN }}
+      - name: Install target branch dependencies
+        if: steps.whippet_lock_change.outputs.src == 'true' && github.event_name == 'pull_request' 
+        run: composer install --no-interaction
+      - name: Whippet describe target branch
+        if: steps.whippet_lock_change.outputs.src == 'true' && github.event_name == 'pull_request'
+        run: |
+          if test -f "whippet.lock"; then
+            EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+            echo "DESCRIBE_TARGET_BRANCH<<$EOF" >> "$GITHUB_ENV"
+            vendor/bin/whippet deps describe >> "$GITHUB_ENV"
+            echo -e "\n" >> "$GITHUB_ENV"
+            echo "$EOF" >> "$GITHUB_ENV"
+          else
+            echo "DESCRIBE_TARGET_BRANCH=''" >> "$GITHUB_ENV"
+          fi
+      - name: Diff the describes
+        if: steps.whippet_lock_change.outputs.src == 'true' && github.event_name == 'pull_request'
+        run: |
+          set +e
+          this_diff=$(diff <(echo "$DESCRIBE_TARGET_BRANCH") <(echo "$DESCRIBE_PR_BRANCH") -u)
+          set -e
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "WHIPPET_DIFF<<$EOF" >> "$GITHUB_ENV"
+          echo "$this_diff" >> "$GITHUB_ENV"
+          echo -e "\n" >> "$GITHUB_ENV"
+          echo "$EOF" >> "$GITHUB_ENV"
+      - name: Add the comment
+        if: github.event_name == 'pull_request' && env.WHIPPET_DIFF != ''
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: whippet_lock_changes
+          message: |
+            Changes to `whippet.lock` detected. The following version changes will be applied:
+            ```diff
+            ${{ env.WHIPPET_DIFF }}
+            ```


### PR DESCRIPTION
This commit expands the workflow so that it runs `whippet deps describe` on the head and target branch for any PR that includes changes to `whippet.lock`. The output of the two `whippet deps describe` is then passed into `diff`, and the output posted in a comment on the PR.

The result is that any PRs that amend `whippet.lock` should receive a comment describing what version changes will be made as a result of the PR (something that isn't clear at the moment, as `whippet.lock` just refers to commit hashes rather than version tags). This functionality could be expanded in future so that e.g. PRs that only modify `whippet.lock` and don't introduce any major version changes are auto-merged.

There's a few things to note about the way this will work:

- The workflow will need read access to not only the repo containing the PR, but also all the Whippet dependencies the `whippet.lock` file references. The default GitHub token used in a workflow only has permission to read the source repo, so we have to pass in a GitHub token with at least read permission for the source repo and all our `dxw-wordpress-plugin` repos.
- `diff` produces an exit code of 1 if it finds differences, which by default causes the workflow to fail, so we run `set +e` before running `diff` the `set -e` after.
- If a PR is subsequently updated with more changes to `whippet.lock`, the original comment will be updated. We could modify this so the original comment is removed and replaced with a new comment if we want to.
- The workflow uses a couple of third-party actions (`dorny/paths-filter@v2` and `marocchino/sticky-pull-request-comment@v2`) that we haven't used before, but both seem well-maintained and widely used.

There's an example of the comment output on this PR on the saluki test site: https://github.com/dxw/saluki-test-site/pull/263. We might want to modify the output in future, but this feels like a good starting point, and is human-readable.

Before we roll this out more widely, each repo it runs on will need access to a GitHub token secret that has the necessary permissions (as shared workflows don't allow you to use secrets within the shared workflow repo - they have to be passed in from the calling workflow). One option might be to create a generic token with all the necessary permissions and use GovPress Tools to set it as a secret on all the necessary repos. GovPress Tools already does something similar for GhostInspector API keys.