### PR TITLE
Use separate tokens to access calling repo and plugin repos

### DIFF
--- a/.github/workflows/whippet-dependencies-validate.yml
+++ b/.github/workflows/whippet-dependencies-validate.yml
@@ -42,12 +42,10 @@ jobs:
           filters: |
             src:
               - 'whippet.lock'
-      - name: authenticate with GitHub CLI and setup git
+      - name: authenticate and setup https git
         if: steps.whippet_lock_change.outputs.src == 'true' && github.event_name == 'pull_request'
         run: |
-          echo "${{ secrets.GH_ACCOUNT_TOKEN }}" | gh auth login --with-token -p https
-          gh auth setup-git
-          git config --global url."https://github.com/".insteadOf 'git@github.com:'
+          git config --global url."https://oauth2:${{ secrets.GH_ACCOUNT_TOKEN }}@github.com/".insteadOf 'git@github.com:'
       - name: Whippet describe current branch
         if: steps.whippet_lock_change.outputs.src == 'true' && github.event_name == 'pull_request'
         run: |

--- a/.github/workflows/whippet-dependencies-validate.yml
+++ b/.github/workflows/whippet-dependencies-validate.yml
@@ -10,11 +10,10 @@ jobs:
   whippet-deps:
     permissions:
       pull-requests: write
+      contents: read
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.GH_ACCOUNT_TOKEN }}
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -64,7 +63,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.base.ref }}
-          token: ${{ secrets.GH_ACCOUNT_TOKEN }}
       - name: Install target branch dependencies
         if: steps.whippet_lock_change.outputs.src == 'true' && github.event_name == 'pull_request' 
         run: composer install --no-interaction

--- a/.github/workflows/whippet-dependencies-validate.yml
+++ b/.github/workflows/whippet-dependencies-validate.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -63,6 +65,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.base.ref }}
+          persist-credentials: false
       - name: Install target branch dependencies
         if: steps.whippet_lock_change.outputs.src == 'true' && github.event_name == 'pull_request' 
         run: composer install --no-interaction


### PR DESCRIPTION
This PR amends the workflow so that the token passed in only needs read access for plugin repos references in `whippet.lock` files. It does this by using the default GitHub token generated in any workflow run to gain access to the contents of the calling repo, then using the passed in token (which will be a token with repo access only for the `dxw-govpress-tools-plugin-reader` account) to access the plugin repos.

We've stopped authenticating via GitHub CLI, because a token to do that requires org:read access, which we don't want to grant; but repo:read access will do the job if we put the token directly in the https URIs used to clone the plugin repos.