### PR TITLE
Enforce references for whippet dependencies

### DIFF
--- a/.github/workflows/whippet-dependencies-validate.yml
+++ b/.github/workflows/whippet-dependencies-validate.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction
       - name: Run Whippet deps validate
-        run: vendor/bin/whippet deps validate
+        run: vendor/bin/whippet deps validate -r
       - name: Check for changes to whippet.lock
         if: github.event_name == 'pull_request'
         uses: dorny/paths-filter@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2024-08-08
+
+### Changed
+
+- Enforces references for whippet dependencies
+
 ## [3.0.0] - 2024-06-11
 
 ### Changed


### PR DESCRIPTION
As part of the work to automate plugin updates, we want to ensure that we don't accidentally deploy a breaking change when running `whippet deps update`. The best way to do this currently is to pin all plugins to a specific git reference (normally the major version tag for the current release).

This change ensures that the workflow will fail if a file in `whippet.json` does not have a reference specified.

See https://github.com/dxw/whippet/pull/245 for where this feature was added to Whippet.