### PR TITLE
Auto-approve PRs that only change `whippet.lock`

### DIFF
--- a/.github/workflows/whippet-dependencies-validate.yml
+++ b/.github/workflows/whippet-dependencies-validate.yml
@@ -42,6 +42,14 @@ jobs:
           filters: |
             src:
               - 'whippet.lock'
+      - name: Check for changes to anything EXCEPT whippet.lock
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v2
+        id: non_whippet_lock_change
+        with:
+          filters: |
+            src:
+              - '**/!(whippet.lock)'
       - name: authenticate and setup https git
         if: steps.whippet_lock_change.outputs.src == 'true' && github.event_name == 'pull_request'
         run: |
@@ -100,3 +108,10 @@ jobs:
             ```diff
             ${{ env.WHIPPET_DIFF }}
             ```
+      - name: Approve whippet.lock-only PRs
+        if: github.event_name == 'pull_request' && steps.non_whippet_lock_change.outputs.src == 'false'
+        run: |
+          gh pr review --approve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        

--- a/.github/workflows/whippet-dependencies-validate.yml
+++ b/.github/workflows/whippet-dependencies-validate.yml
@@ -109,7 +109,7 @@ jobs:
             ${{ env.WHIPPET_DIFF }}
             ```
       - name: Approve whippet.lock-only PRs
-        if: github.event_name == 'pull_request' && steps.non_whippet_lock_change.outputs.src == 'false'
+        if: github.event_name == 'pull_request' && steps.non_whippet_lock_change.outputs.src == 'false' && github.event.pull_request.base.ref == 'develop'
         run: |
           gh pr review --approve
         env:


### PR DESCRIPTION
This change amends the workflow to check if there have been changes to any file except `whippet.lock`. If there have not been, and the workflow has been triggered by a PR, it uses the `GITHUB_TOKEN` generated specifically for this workflow (which has been given pull-request write permissions at the top of the workflow) to approve the PR.

The intention is that I'll update the saluki-test repo to point it's whippet workflow the `main` branch of this repo once this is merged, to enable me to test this there before rolling it out more widely. Once I've confirmed it's working, I'll also restrict the approval step to only fire if the PR author is `dxw-govpress-tools`, so it doesn't auto-approve manually-generated PRs.