### PR TITLE
Point PR approval command at correct branch

### DIFF
--- a/.github/workflows/whippet-dependencies-validate.yml
+++ b/.github/workflows/whippet-dependencies-validate.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Approve whippet.lock-only PRs
         if: github.event_name == 'pull_request' && steps.non_whippet_lock_change.outputs.src == 'false' && github.event.pull_request.base.ref == 'develop'
         run: |
-          gh pr review --approve
+          gh pr review ${{ github.event.pull_request.id }} --approve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         


### PR DESCRIPTION
Because we checkout the target PR branch immediately before running the PR approval, the default behaviour is to try and target a PR that exists from the target branch. So let's specify the PR id instead.