### PR TITLE
Refer to PR by number not ID

### DIFF
--- a/.github/workflows/whippet-dependencies-validate.yml
+++ b/.github/workflows/whippet-dependencies-validate.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Approve whippet.lock-only PRs
         if: github.event_name == 'pull_request' && steps.non_whippet_lock_change.outputs.src == 'false' && github.event.pull_request.base.ref == 'develop'
         run: |
-          gh pr review ${{ github.event.pull_request.id }} --approve
+          gh pr review ${{ github.event.pull_request.number }} --approve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         


### PR DESCRIPTION
The ID is apprently a long string that you don't normally see, and can't be used to reference the PR in a GH command. We should use the integer number instead.