### PR TITLE
Fix/only auto-approve govpress-tools authored PRs

### DIFF
--- a/.github/workflows/whippet-dependencies-validate.yml
+++ b/.github/workflows/whippet-dependencies-validate.yml
@@ -109,7 +109,7 @@ jobs:
             ${{ env.WHIPPET_DIFF }}
             ```
       - name: Approve whippet.lock-only PRs
-        if: github.event_name == 'pull_request' && steps.non_whippet_lock_change.outputs.src == 'false' && github.event.pull_request.base.ref == 'develop'
+        if: github.event_name == 'pull_request' && steps.non_whippet_lock_change.outputs.src == 'false' && github.event.pull_request.base.ref == 'develop' && github.event.pull_request.user.login == 'dxw-govpress-tools'
         run: |
           gh pr review ${{ github.event.pull_request.number }} --approve
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2024-08-08
+
+### Added
+
+- PRs into `develop`, opened by GovPress Tools and that only change `whippet.lock`, are auto-approved.
+
 ## [3.1.0] - 2024-08-08
 
 ### Changed


### PR DESCRIPTION
This PR:

- Amends the workflow so it only approves PRs that have been authored by the GovPress Tools service account. In theory, it'd probably be safe to auto-approve any PRs that only change `whippet.lock`, because they'd only make it to the end of this workflow if the changes were valid, but let's start out conservatively
- Bumps the version to `v3.2.0`. This should be safe to do, because aside from this final change, the workflow is behaving as expected, as can be seen by the auto-approved PR here: https://github.com/dxw/saluki-test-site/pull/348

Merging this won't start the auto-merge of GovPress Tools PRs, as it isn't currently setting its PRs to automerge, so a human will still have to hit the merge button.